### PR TITLE
Revalidate token

### DIFF
--- a/tuya_bulb_control/_tuya_api.py
+++ b/tuya_bulb_control/_tuya_api.py
@@ -110,7 +110,7 @@ class _TuyaApi:
 
             return token
 
-    def _get(self, postfix: str) -> dict:
+    def _get(self, postfix: str, check_token: bool = True) -> dict:
         """
         Performs a GET request at the specified address.
 
@@ -122,12 +122,15 @@ class _TuyaApi:
 
         try:
             response = requests.get(uri, headers=headers).json()
+            if check_token and not response["success"] and response['code'] == 1010:
+                self.__access_token = self.__token()
+                return self._get(postfix, False)
         except Exception:
             raise Exception
 
         return response
 
-    def _post(self, postfix: str, body=None) -> dict:
+    def _post(self, postfix: str, body=None, check_token: bool = True) -> dict:
         """
         Performs a POST request at specified address.
 
@@ -144,6 +147,9 @@ class _TuyaApi:
 
         try:
             response = requests.post(uri, headers=headers, data=body).json()
+            if check_token and not response["success"] and response['code'] == 1010:
+                self.__access_token = self.__token()
+                return self._post(postfix, body, False)
         except Exception:
             raise Exception
 

--- a/tuya_bulb_control/project.ini
+++ b/tuya_bulb_control/project.ini
@@ -1,5 +1,5 @@
 [Info]
-version: 0.1b3
+version: 0.1b4
 project: tuya_bulb_control
 author: Kirill Hickey
 license: MIT


### PR DESCRIPTION
Hey, thanks for working on this. It's great library.

I've been using it for a system tray app to control the light in my office. But I noticed that after about an hour of inactivity the token becomes invalid and all bulb control functions no longer work. You can test it with this code:

```
bulb = Bulb(
    client_id=CLIENT_ID,
    secret_key=SECRET_KEY,
    device_id=DEVICE_ID,
    region_key=REGION_KEY
)

bulb.turn_on()

time.sleep(2)
bulb._TuyaApi__access_token = "invalid"

# Error, will fail to get valid data on _get()
bulb.turn_off() 

```

I've added a workaround in _get that checks the token before returning, and if it returned a bad request, will acquire a new token and try again. The same with _post (although I think that one is not needed, it may be needed in the future).
It will only try to get the token once, not indefinitely.

Thanks again!